### PR TITLE
Refactor quiz flow UI debt and remove stepper-era leftovers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ The UI migration intentionally stopped at Bootstrap 4.x. Do not mix old Bootstra
 
 - answer groups keep their existing IDs such as `#eduGroup`
 - scoring reads the active choice through `label.active input`
-- some radio inputs still share the original `name` values
+- the quiz flow now binds answer messaging through centralized JavaScript instead of inline `onclick` handlers
 
-That behavior is intentionally preserved to avoid changing questionnaire flow, scoring, and generated results. If you ever refactor the answer markup, update all dependent selectors safely before changing this contract.
+The scoring contract above is intentionally preserved to avoid changing questionnaire flow, scoring, and generated results. Radio inputs now use per-question `name` values, but `calculations.js` still reads the active selection from the label state rather than from the radio group names. If you ever refactor the answer markup, update all dependent selectors safely before changing this contract.
 
 ## Quiz Flow Notes
 
@@ -62,7 +62,7 @@ The current UI now behaves like a dramatic one-question-at-a-time quiz show whil
 
 Motion still respects `prefers-reduced-motion`, which disables non-essential animation and hover movement while keeping every state change readable and usable.
 
-Important compatibility note: this redesign does not change questionnaire logic. The app still intentionally preserves the `label.active input` scoring contract, the existing answer group IDs, shared radio naming, and the inline answer handlers because `calculations.js` and `messages.js` still depend on those hooks.
+Important compatibility note: this redesign does not change questionnaire logic. The app still intentionally preserves the `label.active input` scoring contract and the existing answer group IDs because `calculations.js` and `messages.js` still depend on those hooks.
 
 ## Result Range Notes
 
@@ -78,7 +78,7 @@ Legacy contracts intentionally preserved:
 
 - `label.active input` remains the scoring selector contract
 - answer group IDs such as `#eduGroup` remain stable
-- the existing questions, answers, flow, and inline answer handlers remain in place
+- the existing questions, answers, flow, and reveal behavior remain in place
 
 ## Fairness Feedback Notes
 
@@ -107,3 +107,19 @@ Sources used for that limitation check:
 
 - [Cusdis JS SDK attributes](https://github.com/djyde/cusdis/blob/master/public/doc/advanced/sdk.md)
 - [Cusdis reply form source](https://github.com/djyde/cusdis/blob/master/widget/components/Reply.svelte)
+
+## Cleanup Notes
+
+This cleanup pass reduced leftover migration debt without changing the quiz behavior:
+
+- renamed wrapper classes and IDs away from stepper-era names such as `wizard-stepper` and `wizardNext`
+- removed dormant stepper-only CSS selectors that no longer match the one-question quiz flow
+- replaced inline answer/reveal handlers with centralized JavaScript listeners
+- normalized radio `name` attributes to per-question values while keeping the `label.active input` scoring contract intact
+- corrected the legacy `qoute` result hook to `quote`
+
+Intentional debt still left alone:
+
+- panel IDs like `tab1` through `tab6` still exist because they are harmless internal hooks
+- `label.active input` remains the compatibility-sensitive scoring selector
+- answer group IDs such as `#eduGroup` remain stable to avoid changing `calculations.js`

--- a/calculations.js
+++ b/calculations.js
@@ -4,7 +4,7 @@ const RESULT_GROUPS = [
   '#eduGroup', '#virGroup', '#kidGroup', '#boyGroup',
   '#marriageGroup', '#employmentGroup', '#carGroup', '#houseGroup',
   '#cookGroup', '#bedroomGroup', '#socialGroup', '#royalGroup',
-  '#housewiveGroup', '#incomeGroup', '#hairGroup', '#drinkGroup'
+  '#housewifeGroup', '#incomeGroup', '#hairGroup', '#drinkGroup'
 ];
 
 const RAW_SCORE_MIN = 12;
@@ -104,7 +104,7 @@ function calculateResults() {
 
   showCowImages(cowCount, formattedRand);
 
-  document.getElementById('qoute').innerHTML =
+  document.getElementById('quote').innerHTML =
     'Please inform your boyfriend to start budgeting ' + formattedRand +
     ' if he wants to put a ring on that finger.';
 

--- a/docs/SMOKE_TEST.md
+++ b/docs/SMOKE_TEST.md
@@ -66,5 +66,7 @@ Use a mobile width around `390px`.
 - Auto-advance should only trigger after the current visible question is answered.
 - Do not change the `label.active input` scoring selector contract unless all dependent logic is updated safely.
 - Do not rename the answer group IDs without updating every selector in the existing JS.
+- Do not reintroduce shared radio `name` values or inline answer handlers without re-checking the quiz state and message wiring end-to-end.
 - Do not change questionnaire flow or the underlying answer values when adjusting the displayed Rand remap.
+- The final reveal quote hook is `#quote`; keep that selector aligned with both the result markup and `calculations.js`.
 - The 500-character comment guidance is best-effort only unless Cusdis adds an officially supported `maxlength` option.

--- a/index.html
+++ b/index.html
@@ -14,15 +14,15 @@
   </head>
   <body>
     <div class="container">
-      <section id="wizard" aria-labelledby="wizardTitle">
-        <div class="wizard-card">
+      <section id="quizExperience" aria-labelledby="quizTitle">
+        <div class="quiz-card">
           <div class="hero-intro pb-3 mb-4 border-bottom">
             <div class="show-broadcast" aria-hidden="true">
               <span class="broadcast-pill">Quiz Show Edition</span>
               <span class="broadcast-copy">16 questions plus the final reveal</span>
             </div>
 
-            <h1 class="heading-font" id="wizardTitle">Lobola Calculator</h1>
+            <h1 class="heading-font" id="quizTitle">Lobola Calculator</h1>
 
             <p>Designed after 157 hours of consultations, 45 meetings and meeting with over 100 elders</p>
 
@@ -41,7 +41,7 @@
             </div>
           </div>
 
-          <div id="rootwizard" class="quiz-flow wizard-stepper">
+          <div id="quizShell" class="quiz-flow quiz-shell">
             <div class="show-banner" aria-live="polite" aria-atomic="true">
               <div class="show-banner-copy">
                 <p class="show-stage-pill" id="stageEyebrow">Round 1 of 5</p>
@@ -104,28 +104,28 @@
               <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" aria-valuetext="0% complete" style="width: 0%;">0%</div>
             </div>
 
-            <div class="bs-stepper-content px-0">
-              <div class="content" id="tab1" role="tabpanel" aria-labelledby="tab1-trigger">
+            <div class="quiz-content px-0">
+              <div class="quiz-panel" id="tab1">
                 <div class="alert alert-danger validation-alert" id="tab1ValidationAlert" role="alert" aria-live="assertive" aria-atomic="true" hidden></div>
 
                 <div class="row question-row align-items-start">
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">What is your highest level of education?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="eduGroup">
-                      <label class="btn btn-secondary" onclick="noMatric()">
-                        <input type="radio" id="belowMatricRadio" name="quality[25]" value="0" autocomplete="off"> Below Matric
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="belowMatricRadio" name="educationLevel" value="0" data-message-handler="noMatric" autocomplete="off"> Below Matric
                       </label>
-                      <label class="btn btn-secondary" onclick="matric()">
-                        <input type="radio" id="matricRadio" name="quality[25]" value="1" autocomplete="off"> Matric
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="matricRadio" name="educationLevel" value="1" data-message-handler="matric" autocomplete="off"> Matric
                       </label>
-                      <label class="btn btn-secondary" onclick="diploma()">
-                        <input type="radio" id="diplomaRadio" name="quality[25]" value="2" autocomplete="off"> Diploma
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="diplomaRadio" name="educationLevel" value="2" data-message-handler="diploma" autocomplete="off"> Diploma
                       </label>
-                      <label class="btn btn-secondary" onclick="degree()">
-                        <input type="radio" id="degreeRadio" name="quality[25]" value="3" autocomplete="off"> Degree
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="degreeRadio" name="educationLevel" value="3" data-message-handler="degree" autocomplete="off"> Degree
                       </label>
-                      <label class="btn btn-secondary" onclick="aboveDegree()">
-                        <input type="radio" id="aboveDegreeRadio" name="quality[25]" value="4" autocomplete="off"> Above Degree
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="aboveDegreeRadio" name="educationLevel" value="4" data-message-handler="aboveDegree" autocomplete="off"> Above Degree
                       </label>
                     </div>
                   </div>
@@ -135,11 +135,11 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Are you a virgin?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="virGroup">
-                      <label class="btn btn-secondary" onclick="virginYes()">
-                        <input type="radio" id="virginYesRadio" name="quality[25]" value="10" autocomplete="off"> Yes
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="virginYesRadio" name="virginityStatus" value="10" data-message-handler="virginYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="virginNo()">
-                        <input type="radio" id="virginNoRadio" name="quality[25]" value="2" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="virginNoRadio" name="virginityStatus" value="2" data-message-handler="virginNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
@@ -149,40 +149,40 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">How many children do you have?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="kidGroup">
-                      <label class="btn btn-secondary" onclick="kidNone()">
-                        <input type="radio" id="kidNoneRadio" name="quality[25]" value="2" autocomplete="off"> None
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="kidNoneRadio" name="childCount" value="2" data-message-handler="kidNone" autocomplete="off"> None
                       </label>
-                      <label class="btn btn-secondary" onclick="kidOne()">
-                        <input type="radio" id="kidOneRadio" name="quality[25]" value="1" autocomplete="off"> 1
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="kidOneRadio" name="childCount" value="1" data-message-handler="kidOne" autocomplete="off"> 1
                       </label>
-                      <label class="btn btn-secondary" onclick="kidTwo()">
-                        <input type="radio" id="kidTwoRadio" name="quality[25]" value="0" autocomplete="off"> 2
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="kidTwoRadio" name="childCount" value="0" data-message-handler="kidTwo" autocomplete="off"> 2
                       </label>
-                      <label class="btn btn-secondary" onclick="kidThree()">
-                        <input type="radio" id="kidThreeRadio" name="quality[25]" value="0" autocomplete="off"> 3 or more
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="kidThreeRadio" name="childCount" value="0" data-message-handler="kidThree" autocomplete="off"> 3 or more
                       </label>
                     </div>
                   </div>
                 </div>
               </div>
-              <div class="content" id="tab2" role="tabpanel" aria-labelledby="tab2-trigger">
+              <div class="quiz-panel" id="tab2">
                 <div class="alert alert-danger validation-alert" id="tab2ValidationAlert" role="alert" aria-live="assertive" aria-atomic="true" hidden></div>
 
                 <div class="row question-row align-items-start">
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">How many boyfriends have you had in the past?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="boyGroup">
-                      <label class="btn btn-secondary" onclick="boyfriendLevelOne()">
-                        <input type="radio" id="boyfriendLevelOneRadio" name="quality[25]" value="3" autocomplete="off"> 0-5
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="boyfriendLevelOneRadio" name="boyfriendCount" value="3" data-message-handler="boyfriendLevelOne" autocomplete="off"> 0-5
                       </label>
-                      <label class="btn btn-secondary" onclick="boyfriendLevelTwo()">
-                        <input type="radio" id="boyfriendLevelTwoRadio" name="quality[25]" value="2" autocomplete="off"> 6-10
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="boyfriendLevelTwoRadio" name="boyfriendCount" value="2" data-message-handler="boyfriendLevelTwo" autocomplete="off"> 6-10
                       </label>
-                      <label class="btn btn-secondary" onclick="boyfriendLevelThree()">
-                        <input type="radio" id="boyfriendLevelThreeRadio" name="quality[25]" value="1" autocomplete="off"> 10-15
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="boyfriendLevelThreeRadio" name="boyfriendCount" value="1" data-message-handler="boyfriendLevelThree" autocomplete="off"> 10-15
                       </label>
-                      <label class="btn btn-secondary" onclick="boyfriendLevelFour()">
-                        <input type="radio" id="boyfriendLevelFourRadio" name="quality[25]" value="0" autocomplete="off"> 16 or more
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="boyfriendLevelFourRadio" name="boyfriendCount" value="0" data-message-handler="boyfriendLevelFour" autocomplete="off"> 16 or more
                       </label>
                     </div>
                   </div>
@@ -192,11 +192,11 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Have you been married before?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="marriageGroup">
-                      <label class="btn btn-secondary" onclick="marriedYes()">
-                        <input type="radio" id="marriedYesRadio" name="quality[25]" value="1" autocomplete="off"> Yes
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="marriedYesRadio" name="marriageHistory" value="1" data-message-handler="marriedYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="marriedNo()">
-                        <input type="radio" id="marriedNoRadio" name="quality[25]" value="3" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="marriedNoRadio" name="marriageHistory" value="3" data-message-handler="marriedNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
@@ -206,38 +206,38 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">What is your current employment status?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="employmentGroup">
-                      <label class="btn btn-secondary" onclick="employmentJob()">
-                        <input type="radio" id="employmentJobRadio" name="quality[25]" value="2" autocomplete="off"> Job
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="employmentJobRadio" name="employmentStatus" value="2" data-message-handler="employmentJob" autocomplete="off"> Job
                       </label>
-                      <label class="btn btn-secondary" onclick="employmentCareer()">
-                        <input type="radio" id="employmentCareerRadio" name="quality[25]" value="3" autocomplete="off"> Career driven
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="employmentCareerRadio" name="employmentStatus" value="3" data-message-handler="employmentCareer" autocomplete="off"> Career driven
                       </label>
-                      <label class="btn btn-secondary" onclick="employmentUnmployed()">
-                        <input type="radio" id="employmentUnmployedRadio" name="quality[25]" value="0" autocomplete="off"> Unemployed
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="employmentUnemployedRadio" name="employmentStatus" value="0" data-message-handler="employmentUnemployed" autocomplete="off"> Unemployed
                       </label>
-                      <label class="btn btn-secondary" onclick="employmentBusiness()">
-                        <input type="radio" id="employmentBusinessRadio" name="quality[25]" value="4" autocomplete="off"> Business owner
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="employmentBusinessRadio" name="employmentStatus" value="4" data-message-handler="employmentBusiness" autocomplete="off"> Business owner
                       </label>
-                      <label class="btn btn-secondary" onclick="employmentStudent()">
-                        <input type="radio" id="employmentStudentRadio" name="quality[25]" value="1" autocomplete="off"> Student
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="employmentStudentRadio" name="employmentStatus" value="1" data-message-handler="employmentStudent" autocomplete="off"> Student
                       </label>
                     </div>
                   </div>
                 </div>
               </div>
 
-              <div class="content" id="tab3" role="tabpanel" aria-labelledby="tab3-trigger">
+              <div class="quiz-panel" id="tab3">
                 <div class="alert alert-danger validation-alert" id="tab3ValidationAlert" role="alert" aria-live="assertive" aria-atomic="true" hidden></div>
 
                 <div class="row question-row align-items-start">
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Do you own a car?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="carGroup">
-                      <label class="btn btn-secondary" onclick="carYes()">
-                        <input type="radio" id="carYesRadio" name="quality[25]" value="3" autocomplete="off"> Yes
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="carYesRadio" name="carOwnership" value="3" data-message-handler="carYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="carNo()">
-                        <input type="radio" id="carNoRadio" name="quality[25]" value="1" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="carNoRadio" name="carOwnership" value="1" data-message-handler="carNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
@@ -247,11 +247,11 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Do you own a house?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="houseGroup">
-                      <label class="btn btn-secondary" onclick="houseYes()">
-                        <input type="radio" id="houseYesRadio" name="quality[25]" value="4" autocomplete="off"> Yes
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="houseYesRadio" name="houseOwnership" value="4" data-message-handler="houseYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="houseNo()">
-                        <input type="radio" id="houseNoRadio" name="quality[25]" value="2" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="houseNoRadio" name="houseOwnership" value="2" data-message-handler="houseNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
@@ -261,44 +261,44 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Can you cook?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="cookGroup">
-                      <label class="btn btn-secondary" onclick="cookLevelOne()">
-                        <input type="radio" id="cookLevelOneRadio" name="quality[25]" value="0" autocomplete="off"> I can&#39;t cook
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="cookLevelOneRadio" name="cookingSkill" value="0" data-message-handler="cookLevelOne" autocomplete="off"> I can&#39;t cook
                       </label>
-                      <label class="btn btn-secondary" onclick="cookLevelTwo()">
-                        <input type="radio" id="cookLevelTwoRadio" name="quality[25]" value="1" autocomplete="off"> I try
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="cookLevelTwoRadio" name="cookingSkill" value="1" data-message-handler="cookLevelTwo" autocomplete="off"> I try
                       </label>
-                      <label class="btn btn-secondary" onclick="cookLevelThree()">
-                        <input type="radio" id="cookLevelThreeRadio" name="quality[25]" value="2" autocomplete="off"> I can cook but I&#39;m lazy to
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="cookLevelThreeRadio" name="cookingSkill" value="2" data-message-handler="cookLevelThree" autocomplete="off"> I can cook but I&#39;m lazy to
                       </label>
-                      <label class="btn btn-secondary" onclick="cookLevelFour()">
-                        <input type="radio" id="cookLevelFourRadio" name="quality[25]" value="3" autocomplete="off"> I can cook and I love it!
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="cookLevelFourRadio" name="cookingSkill" value="3" data-message-handler="cookLevelFour" autocomplete="off"> I can cook and I love it!
                       </label>
                     </div>
                   </div>
                 </div>
               </div>
 
-              <div class="content" id="tab4" role="tabpanel" aria-labelledby="tab4-trigger">
+              <div class="quiz-panel" id="tab4">
                 <div class="alert alert-danger validation-alert" id="tab4ValidationAlert" role="alert" aria-live="assertive" aria-atomic="true" hidden></div>
 
                 <div class="row question-row align-items-start">
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Rate your performance in the bedroom?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="bedroomGroup">
-                      <label class="btn btn-secondary" onclick="bedLevelOne()">
-                        <input type="radio" id="bedLevelOneRadio" name="quality[25]" value="0" autocomplete="off"> It&#39;s not my thing
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="bedLevelOneRadio" name="bedroomSkill" value="0" data-message-handler="bedLevelOne" autocomplete="off"> It&#39;s not my thing
                       </label>
-                      <label class="btn btn-secondary" onclick="bedLevelTwo()">
-                        <input type="radio" id="bedLevelTwoRadio" name="quality[25]" value="1" autocomplete="off"> I can do the basics
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="bedLevelTwoRadio" name="bedroomSkill" value="1" data-message-handler="bedLevelTwo" autocomplete="off"> I can do the basics
                       </label>
-                      <label class="btn btn-secondary" onclick="bedLevelThree()">
-                        <input type="radio" id="bedLevelThreeRadio" name="quality[25]" value="2" autocomplete="off"> I&#39;m good shame!
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="bedLevelThreeRadio" name="bedroomSkill" value="2" data-message-handler="bedLevelThree" autocomplete="off"> I&#39;m good shame!
                       </label>
-                      <label class="btn btn-secondary" onclick="bedLevelFour()">
-                        <input type="radio" id="bedLevelFourRadio" name="quality[25]" value="3" autocomplete="off"> I make him scream
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="bedLevelFourRadio" name="bedroomSkill" value="3" data-message-handler="bedLevelFour" autocomplete="off"> I make him scream
                       </label>
-                      <label class="btn btn-secondary" onclick="bedLevelFive()">
-                        <input type="radio" id="bedLevelFiveRadio" name="quality[25]" value="4" autocomplete="off"> I&#39;m dangerous!!! Ingozi!
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="bedLevelFiveRadio" name="bedroomSkill" value="4" data-message-handler="bedLevelFive" autocomplete="off"> I&#39;m dangerous!!! Ingozi!
                       </label>
                     </div>
                   </div>
@@ -308,11 +308,11 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Are you a socialite? Uthanda izinto? (clubbing,shisanyamas,parties are your thing)</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="socialGroup">
-                      <label class="btn btn-secondary" onclick="socialiteYes()">
-                        <input type="radio" id="socialiteYesRadio" name="quality[25]" value="1" autocomplete="off"> Yes
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="socialiteYesRadio" name="socialiteStatus" value="1" data-message-handler="socialiteYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="socialiteNo()">
-                        <input type="radio" id="socialiteNoRadio" name="quality[25]" value="3" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="socialiteNoRadio" name="socialiteStatus" value="3" data-message-handler="socialiteNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
@@ -322,29 +322,29 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Are you from a family of royalty?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="royalGroup">
-                      <label class="btn btn-secondary" onclick="royalityYes()">
-                        <input type="radio" id="royalityYesRadio" name="quality[25]" value="15" autocomplete="off"> Yes
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="royaltyYesRadio" name="royaltyStatus" value="15" data-message-handler="royaltyYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="royalityNo()">
-                        <input type="radio" id="royalityNoRadio" name="quality[25]" value="3" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="royaltyNoRadio" name="royaltyStatus" value="3" data-message-handler="royaltyNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
                 </div>
               </div>
 
-              <div class="content" id="tab5" role="tabpanel" aria-labelledby="tab5-trigger">
+              <div class="quiz-panel" id="tab5">
                 <div class="alert alert-danger validation-alert" id="tab5ValidationAlert" role="alert" aria-live="assertive" aria-atomic="true" hidden></div>
 
                 <div class="row question-row align-items-start">
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Are you planning to be a housewife?</div>
                   <div class="col-md-8 col-lg-9">
-                    <div class="btn-group-toggle option-group" data-toggle="buttons" id="housewiveGroup">
-                      <label class="btn btn-secondary" onclick="housewiveYes()">
-                        <input type="radio" id="housewiveYesRadio" name="quality[25]" value="1" autocomplete="off"> Yes
+                    <div class="btn-group-toggle option-group" data-toggle="buttons" id="housewifeGroup">
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="housewifeYesRadio" name="housewifePlan" value="1" data-message-handler="housewifeYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="housewiveNo()">
-                        <input type="radio" id="housewiveNoRadio" name="quality[25]" value="3" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="housewifeNoRadio" name="housewifePlan" value="3" data-message-handler="housewifeNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
@@ -354,11 +354,11 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Do you make more money(income) than your boyfriend?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="incomeGroup">
-                      <label class="btn btn-secondary" onclick="incomeYes()">
-                        <input type="radio" id="incomeYesRadio" name="quality[25]" value="3" autocomplete="off"> Yes
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="incomeYesRadio" name="higherIncome" value="3" data-message-handler="incomeYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="incomeNo()">
-                        <input type="radio" id="incomeNoRadio" name="quality[25]" value="1" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="incomeNoRadio" name="higherIncome" value="1" data-message-handler="incomeNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
@@ -368,11 +368,11 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Are you gonna ask for your hair money? Imali yekhanda?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="hairGroup">
-                      <label class="btn btn-secondary" onclick="hairYes()">
-                        <input type="radio" id="hairYesRadio" name="quality[25]" value="0" autocomplete="off"> Yes
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="hairYesRadio" name="hairAllowance" value="0" data-message-handler="hairYes" autocomplete="off"> Yes
                       </label>
-                      <label class="btn btn-secondary" onclick="hairNo()">
-                        <input type="radio" id="hairNoRadio" name="quality[25]" value="2" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="hairNoRadio" name="hairAllowance" value="2" data-message-handler="hairNo" autocomplete="off"> No
                       </label>
                     </div>
                   </div>
@@ -382,25 +382,25 @@
                   <div class="col-md-4 col-lg-3 question-label mb-2 mb-md-0">Do you drink?</div>
                   <div class="col-md-8 col-lg-9">
                     <div class="btn-group-toggle option-group" data-toggle="buttons" id="drinkGroup">
-                      <label class="btn btn-secondary" onclick="drinkLevelOne()">
-                        <input type="radio" id="drinkLevelOneRadio" name="quality[25]" value="3" autocomplete="off"> No
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="drinkLevelOneRadio" name="drinkingLevel" value="3" data-message-handler="drinkLevelOne" autocomplete="off"> No
                       </label>
-                      <label class="btn btn-secondary" onclick="drinkLevelTwo()">
-                        <input type="radio" id="drinkLevelTwoRadio" name="quality[25]" value="2" autocomplete="off"> I&#39;m a light/occasional drinker
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="drinkLevelTwoRadio" name="drinkingLevel" value="2" data-message-handler="drinkLevelTwo" autocomplete="off"> I&#39;m a light/occasional drinker
                       </label>
-                      <label class="btn btn-secondary" onclick="drinkLevelThree()">
-                        <input type="radio" id="drinkLevelThreeRadio" name="quality[25]" value="0" autocomplete="off"> I get sloshed...Ngiyabukha!
+                      <label class="btn btn-secondary">
+                        <input type="radio" id="drinkLevelThreeRadio" name="drinkingLevel" value="0" data-message-handler="drinkLevelThree" autocomplete="off"> I get sloshed...Ngiyabukha!
                       </label>
                     </div>
                   </div>
                 </div>
               </div>
 
-              <div class="content finish-panel" id="tab6" role="tabpanel" aria-labelledby="tab6-trigger">
+              <div class="quiz-panel result-panel" id="tab6">
                 <div class="result-board">
                   <p class="finish-kicker">All 16 answers are locked in. Step into the reveal when you are ready.</p>
 
-                  <button type="button" id="resultCalc" class="btn btn-success btn-lg mb-3" onclick="calculateResults()">Reveal Final Quote</button>
+                  <button type="button" id="resultCalc" class="btn btn-success btn-lg mb-3">Reveal Final Quote</button>
 
                   <div class="result-stage">
                     <p class="result-label">Estimated lobola</p>
@@ -409,7 +409,7 @@
 
                     <p id="scoreSummary" class="result-score"></p>
 
-                    <p id="qoute" class="heading-font result-quote"></p>
+                    <p id="quote" class="heading-font result-quote"></p>
 
                     <div class="result-herd">
                       <div id="cowImages"></div>
@@ -447,11 +447,11 @@
               </div>
             </div>
 
-            <div class="wizard-actions quiz-actions d-flex flex-column flex-sm-row justify-content-between align-items-stretch align-items-sm-center mt-4">
+            <div class="quiz-actions d-flex flex-column flex-sm-row justify-content-between align-items-stretch align-items-sm-center mt-4">
               <p class="quiz-nav-note mb-3 mb-sm-0" id="quizNavNote">Choose an answer to lock it in and move to the next question.</p>
               <div class="quiz-nav-buttons d-flex flex-column flex-sm-row align-items-stretch align-items-sm-center">
-                <button type="button" id="wizardPrevious" class="btn btn-outline-secondary mb-2 mb-sm-0">Previous Question</button>
-                <button type="button" id="wizardNext" class="btn btn-primary">Continue</button>
+                <button type="button" id="quizPrevious" class="btn btn-outline-secondary mb-2 mb-sm-0">Previous Question</button>
+                <button type="button" id="quizNext" class="btn btn-primary">Continue</button>
               </div>
             </div>
           </div>
@@ -478,8 +478,8 @@
     <script>
       document.addEventListener('DOMContentLoaded', function () {
         var SELECTORS = {
-          panel: '.bs-stepper-content > .content',
-          panelContainer: '.bs-stepper-content',
+          panel: '.quiz-content > .quiz-panel',
+          panelContainer: '.quiz-content',
           progressBar: '.progress-bar',
           questionRow: '.question-row',
           optionGroup: '.option-group[id]',
@@ -488,31 +488,31 @@
         };
         var AUTO_ADVANCE_DELAY_MS = 380;
         var NAVIGATION_LOCK_MS = 60;
-        var stepperEl = document.getElementById('rootwizard');
-        var progressBar = stepperEl.querySelector(SELECTORS.progressBar);
-        var panelContainer = stepperEl.querySelector(SELECTORS.panelContainer);
-        var allPanels = Array.prototype.slice.call(stepperEl.querySelectorAll(SELECTORS.panel));
-        var finishPanel = document.getElementById('tab6');
+        var quizShellEl = document.getElementById('quizShell');
+        var progressBar = quizShellEl.querySelector(SELECTORS.progressBar);
+        var panelContainer = quizShellEl.querySelector(SELECTORS.panelContainer);
+        var allPanels = Array.prototype.slice.call(quizShellEl.querySelectorAll(SELECTORS.panel));
+        var resultPanelEl = document.getElementById('tab6');
         var questionPanels = allPanels.filter(function (panel) {
-          return panel !== finishPanel;
+          return panel !== resultPanelEl;
         });
-        var previousButton = document.getElementById('wizardPrevious');
-        var nextButton = document.getElementById('wizardNext');
+        var previousButton = document.getElementById('quizPrevious');
+        var nextButton = document.getElementById('quizNext');
         var navNoteEl = document.getElementById('quizNavNote');
-        var roundMarkers = Array.prototype.slice.call(stepperEl.querySelectorAll('.quiz-round-marker'));
+        var roundMarkers = Array.prototype.slice.call(quizShellEl.querySelectorAll('.quiz-round-marker'));
         var messageInfoDialog = document.getElementById('messageInfoDialog');
         var resultButton = document.getElementById('resultCalc');
-        var resultStageEl = finishPanel ? finishPanel.querySelector('.result-stage') : null;
+        var resultStageEl = resultPanelEl ? resultPanelEl.querySelector('.result-stage') : null;
         var feedbackCommentShell = document.getElementById('feedbackCommentShell');
         var feedbackCommentHelp = document.getElementById('feedbackCommentHelp');
-        var feedbackButtons = finishPanel ? Array.prototype.slice.call(finishPanel.querySelectorAll('[data-feedback-vote]')) : [];
+        var feedbackButtons = resultPanelEl ? Array.prototype.slice.call(resultPanelEl.querySelectorAll('[data-feedback-vote]')) : [];
         var cusdisThreadEl = document.getElementById('cusdis_thread');
         var cusdisPlaceholderEl = document.getElementById('cusdisPlaceholder');
         var pointsEl = document.getElementById('points');
         var scoreSummaryEl = document.getElementById('scoreSummary');
-        var quoteEl = document.getElementById('qoute');
+        var quoteEl = document.getElementById('quote');
         var cowImagesEl = document.getElementById('cowImages');
-        var showBannerEl = stepperEl.querySelector('.show-banner');
+        var showBannerEl = quizShellEl.querySelector('.show-banner');
         var stageEyebrowEl = document.getElementById('stageEyebrow');
         var stageTitleEl = document.getElementById('stageTitle');
         var stageDescriptionEl = document.getElementById('stageDescription');
@@ -531,7 +531,6 @@
         var navigationLockTimer = null;
         var autoAdvanceTimer = null;
         var autoAdvanceQuestionIndex = null;
-        var selectedFeedbackVote = '';
         var cusdisRequested = false;
         var cusdisReady = false;
         var STAGE_META = [
@@ -577,6 +576,14 @@
           element.classList.add(className);
         }
 
+        function runMessageHandler(handlerName) {
+          if (!handlerName || typeof window[handlerName] !== 'function') {
+            return;
+          }
+
+          window[handlerName]();
+        }
+
         function getSelectedGroupInput(groupSelector) {
           return groupSelector ? document.querySelector(groupSelector + ' ' + SELECTORS.activeChoiceInput) : null;
         }
@@ -605,8 +612,8 @@
           }
 
           autoAdvanceQuestionIndex = null;
-          stepperEl.classList.remove('is-auto-advancing');
-          stepperEl.removeAttribute('data-auto-advance-question');
+          quizShellEl.classList.remove('is-auto-advancing');
+          quizShellEl.removeAttribute('data-auto-advance-question');
         }
 
         function beginNavigationLock() {
@@ -739,24 +746,24 @@
         }
 
         function resetResultRevealState() {
-          if (!finishPanel) {
+          if (!resultPanelEl) {
             return;
           }
 
-          finishPanel.classList.remove('finish-revealed', 'result-spotlight');
-          finishPanel.removeAttribute('data-feedback-selection');
+          resultPanelEl.classList.remove('finish-revealed', 'result-spotlight');
+          resultPanelEl.removeAttribute('data-feedback-selection');
 
           if (resultButton) {
             resultButton.classList.remove('reveal-armed');
           }
 
           if (!prefersReducedMotion) {
-            void finishPanel.offsetWidth;
+            void resultPanelEl.offsetWidth;
           }
         }
 
         function revealResultState() {
-          if (!finishPanel || !resultStageEl || !pointsEl || !quoteEl) {
+          if (!resultPanelEl || !resultStageEl || !pointsEl || !quoteEl) {
             return;
           }
 
@@ -769,10 +776,10 @@
           }
 
           replayAnimation(resultStageEl, 'result-spotlight');
-          finishPanel.classList.add('finish-revealed');
-          finishPanel.classList.add('result-spotlight');
+          resultPanelEl.classList.add('finish-revealed');
+          resultPanelEl.classList.add('result-spotlight');
           decorateCowImages();
-          replayAnimation(finishPanel, 'result-pop');
+          replayAnimation(resultPanelEl, 'result-pop');
         }
 
         function clearCalculatedResult() {
@@ -807,8 +814,8 @@
 
           currentMode = 'question';
           currentQuestionIndex = index;
-          stepperEl.setAttribute('data-current-question', String(index + 1));
-          stepperEl.setAttribute('data-current-round', String(entry.panelIndex + 1));
+          quizShellEl.setAttribute('data-current-question', String(index + 1));
+          quizShellEl.setAttribute('data-current-round', String(entry.panelIndex + 1));
 
           questionPanels.forEach(function (panel) {
             var isCurrentPanel = panel === entry.panel;
@@ -825,8 +832,8 @@
             item.row.classList.toggle('is-question-complete', !!getSelectedGroupInput(item.groupSelector));
           });
 
-          if (finishPanel) {
-            finishPanel.hidden = true;
+          if (resultPanelEl) {
+            resultPanelEl.hidden = true;
           }
 
           syncQuestionBanner(entry);
@@ -837,8 +844,8 @@
         function showResultScreen() {
           currentMode = 'result';
           currentQuestionIndex = totalQuestions;
-          stepperEl.setAttribute('data-current-question', 'result');
-          stepperEl.setAttribute('data-current-round', String(STAGE_META.length));
+          quizShellEl.setAttribute('data-current-question', 'result');
+          quizShellEl.setAttribute('data-current-round', String(STAGE_META.length));
 
           questionPanels.forEach(function (panel) {
             panel.hidden = true;
@@ -850,13 +857,13 @@
             entry.row.classList.remove('is-active');
           });
 
-          if (finishPanel) {
-            finishPanel.hidden = false;
+          if (resultPanelEl) {
+            resultPanelEl.hidden = false;
           }
 
           syncResultBanner();
           syncNavigation();
-          replayAnimation(finishPanel, 'panel-enter');
+          replayAnimation(resultPanelEl, 'panel-enter');
         }
 
         function moveToNextQuestion() {
@@ -903,8 +910,8 @@
           }
 
           autoAdvanceQuestionIndex = currentQuestionIndex;
-          stepperEl.classList.add('is-auto-advancing');
-          stepperEl.setAttribute('data-auto-advance-question', String(autoAdvanceQuestionIndex + 1));
+          quizShellEl.classList.add('is-auto-advancing');
+          quizShellEl.setAttribute('data-auto-advance-question', String(autoAdvanceQuestionIndex + 1));
           autoAdvanceTimer = window.setTimeout(function () {
             var entry = questionEntries[autoAdvanceQuestionIndex];
 
@@ -936,6 +943,7 @@
             var activeLabel = entry.groupSelector ? document.querySelector(entry.groupSelector + ' label.active') : null;
 
             if (!entry.row.hidden && getSelectedGroupInput(entry.groupSelector)) {
+              runMessageHandler(event.target.getAttribute('data-message-handler'));
               replayAnimation(activeLabel, 'choice-lock');
               syncQuestionBanner(entry);
               scheduleAutoAdvance();
@@ -953,9 +961,13 @@
           });
         }
 
-        function updateFeedbackSelection(vote) {
-          selectedFeedbackVote = vote;
+        if (resultButton) {
+          resultButton.addEventListener('click', function () {
+            calculateResults();
+          });
+        }
 
+        function updateFeedbackSelection(vote) {
           feedbackButtons.forEach(function (button) {
             var isSelected = button.getAttribute('data-feedback-vote') === vote;
 
@@ -963,9 +975,9 @@
             button.setAttribute('aria-pressed', String(isSelected));
           });
 
-          if (finishPanel) {
-            finishPanel.classList.add('feedback-engaged');
-            finishPanel.setAttribute('data-feedback-selection', vote);
+          if (resultPanelEl) {
+            resultPanelEl.classList.add('feedback-engaged');
+            resultPanelEl.setAttribute('data-feedback-selection', vote);
           }
 
           if (feedbackCommentShell) {
@@ -980,16 +992,14 @@
         }
 
         function resetFeedbackState() {
-          selectedFeedbackVote = '';
-
           feedbackButtons.forEach(function (button) {
             button.classList.remove('is-selected');
             button.setAttribute('aria-pressed', 'false');
           });
 
-          if (finishPanel) {
-            finishPanel.classList.remove('feedback-engaged');
-            finishPanel.removeAttribute('data-feedback-selection');
+          if (resultPanelEl) {
+            resultPanelEl.classList.remove('feedback-engaged');
+            resultPanelEl.removeAttribute('data-feedback-selection');
           }
 
           if (feedbackCommentShell) {
@@ -1160,12 +1170,12 @@
           return totalQuestions;
         }
 
-        Array.prototype.slice.call(stepperEl.querySelectorAll('.validation-alert')).forEach(function (alertEl) {
+        Array.prototype.slice.call(quizShellEl.querySelectorAll('.validation-alert')).forEach(function (alertEl) {
           alertEl.hidden = true;
         });
 
-        if (finishPanel) {
-          finishPanel.hidden = true;
+        if (resultPanelEl) {
+          resultPanelEl.hidden = true;
         }
 
         if (getInitialQuestionIndex() >= totalQuestions) {

--- a/messages.js
+++ b/messages.js
@@ -37,7 +37,7 @@ function marriedNo()  { setMessage("Let's hope your boyfriend can afford this lo
 // --- Employment ---
 function employmentJob()       { setMessage("We all started there...phusha phanta"); }
 function employmentCareer()    { setMessage("Nice! Keep it up"); }
-function employmentUnmployed() { setMessage("Hmmmmmmmmm...keep trying!"); }
+function employmentUnemployed() { setMessage("Hmmmmmmmmm...keep trying!"); }
 function employmentBusiness()  { setMessage("Keep it up hustler, we need more people like you"); }
 function employmentStudent()   { setMessage("What's the rush? Focus on your studies"); }
 
@@ -67,12 +67,12 @@ function socialiteYes() { setMessage("Ehlisa phela, usuzoba umama wasekhaya...kh
 function socialiteNo()  { setMessage("A step in the right direction...you can still go out with your hubby"); }
 
 // --- Royalty ---
-function royalityYes() { setMessage("Ngempela?"); }
-function royalityNo()  { setMessage("Like the rest of us :-)"); }
+function royaltyYes() { setMessage("Ngempela?"); }
+function royaltyNo()  { setMessage("Like the rest of us :-)"); }
 
 // --- Housewife ---
-function housewiveYes() { setMessage("Yeka ukuvilapha oe!"); }
-function housewiveNo()  { setMessage("Nothing is more attractive than a hustler...Professional hustling you know what I mean"); }
+function housewifeYes() { setMessage("Yeka ukuvilapha oe!"); }
+function housewifeNo()  { setMessage("Nothing is more attractive than a hustler...Professional hustling you know what I mean"); }
 
 // --- Income ---
 function incomeYes() { setMessage("Yey! Please be humble...I'm sure he feels the pressure already"); }

--- a/quiz-show.css
+++ b/quiz-show.css
@@ -72,13 +72,13 @@ body::after {
   max-width: 1260px;
 }
 
-#wizard {
+#quizExperience {
   position: relative;
   padding: 2.75rem 0 4rem;
 }
 
-#wizard::before,
-#wizard::after {
+#quizExperience::before,
+#quizExperience::after {
   content: "";
   position: absolute;
   top: 0;
@@ -90,12 +90,12 @@ body::after {
   filter: blur(18px);
 }
 
-#wizard::before {
+#quizExperience::before {
   left: -8vw;
   background: radial-gradient(circle, rgba(103, 161, 255, 0.52), transparent 66%);
 }
 
-#wizard::after {
+#quizExperience::after {
   right: -8vw;
   background: radial-gradient(circle, rgba(255, 199, 86, 0.4), transparent 68%);
 }
@@ -108,7 +108,7 @@ body::after {
   font-family: "Indie Flower", cursive;
 }
 
-.wizard-card {
+.quiz-card {
   position: relative;
   overflow: hidden;
   border: 1px solid rgba(122, 175, 255, 0.24);
@@ -124,7 +124,7 @@ body::after {
   padding: clamp(1.35rem, 2.8vw, 2.6rem);
 }
 
-.wizard-card::before {
+.quiz-card::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -135,7 +135,7 @@ body::after {
   pointer-events: none;
 }
 
-.wizard-card::after {
+.quiz-card::after {
   content: "";
   position: absolute;
   left: 1.4rem;
@@ -148,7 +148,7 @@ body::after {
     radial-gradient(circle, rgba(255, 231, 170, 0.94) 0 34%, transparent 35%) left center/1.7rem 0.72rem repeat-x;
 }
 
-.wizard-card > * {
+.quiz-card > * {
   position: relative;
   z-index: 1;
 }
@@ -484,150 +484,7 @@ body::after {
   opacity: 0.92;
 }
 
-.wizard-stepper .bs-stepper-header {
-  flex-wrap: wrap;
-  align-items: stretch;
-  gap: 0.7rem;
-  margin: 0 auto 1.5rem;
-}
-
-.wizard-stepper .step {
-  flex: 1 1 9rem;
-}
-
-.wizard-stepper .line {
-  flex: 0 0 0.85rem;
-  align-self: center;
-  height: 4px;
-  margin: 0;
-  border-radius: 999px;
-  background:
-    linear-gradient(90deg, rgba(255, 216, 124, 0.7), rgba(114, 173, 255, 0.4));
-  box-shadow: 0 0 0.9rem rgba(92, 154, 255, 0.12);
-  transition: background 0.24s ease, opacity 0.24s ease;
-}
-
-.wizard-stepper .step-trigger {
-  position: relative;
-  overflow: hidden;
-  width: 100%;
-  min-height: 100%;
-  justify-content: flex-start;
-  gap: 0.8rem;
-  padding: 1rem 1rem;
-  text-align: left;
-  color: var(--ink-soft);
-  border: 1px solid rgba(114, 173, 255, 0.18);
-  border-radius: 1.3rem;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02)),
-    linear-gradient(180deg, rgba(19, 38, 86, 0.96), rgba(8, 17, 42, 0.98));
-  box-shadow:
-    0 1.1rem 2rem rgba(0, 0, 0, 0.2),
-    inset 0 1px 0 rgba(255, 255, 255, 0.05);
-  transition:
-    transform 0.18s ease,
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    background-color 0.2s ease,
-    color 0.2s ease;
-}
-
-.wizard-stepper .step-trigger::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background:
-    linear-gradient(90deg, rgba(255, 217, 130, 0.08), transparent 24%, transparent 76%, rgba(112, 179, 255, 0.08)),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.08), transparent 48%);
-  pointer-events: none;
-}
-
-.wizard-stepper .step-trigger:disabled {
-  opacity: 1;
-}
-
-.wizard-stepper .step.is-upcoming .step-trigger {
-  color: rgba(213, 223, 243, 0.62);
-}
-
-.wizard-stepper .step.is-complete .step-trigger {
-  color: #eef7ff;
-  border-color: rgba(114, 173, 255, 0.3);
-  background:
-    linear-gradient(180deg, rgba(111, 176, 255, 0.16), rgba(16, 41, 102, 0.26)),
-    linear-gradient(180deg, rgba(18, 38, 84, 0.96), rgba(8, 17, 42, 0.98));
-}
-
-.wizard-stepper .step.is-current .step-trigger,
-.wizard-stepper .step.active .step-trigger {
-  color: #fff6df;
-  border-color: rgba(255, 216, 124, 0.64);
-  background:
-    radial-gradient(circle at 50% 12%, rgba(255, 209, 106, 0.24), transparent 52%),
-    linear-gradient(135deg, rgba(255, 197, 90, 0.18), rgba(39, 77, 181, 0.2)),
-    linear-gradient(180deg, rgba(18, 38, 84, 0.98), rgba(9, 18, 44, 0.99));
-  box-shadow:
-    0 1.45rem 2.5rem rgba(0, 0, 0, 0.28),
-    0 0 0 0.2rem rgba(255, 205, 103, 0.14),
-    0 0 1.4rem rgba(255, 205, 103, 0.12);
-  transform: translateY(-2px);
-}
-
-.wizard-stepper .bs-stepper-circle {
-  flex: 0 0 auto;
-  width: 2.6rem;
-  height: 2.6rem;
-  background: linear-gradient(180deg, rgba(11, 21, 52, 0.98), rgba(8, 16, 36, 0.98));
-  color: #a8d5ff;
-  border: 1px solid rgba(114, 173, 255, 0.2);
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
-    0 0 0 1px rgba(255, 216, 124, 0.05);
-  transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.wizard-stepper .step.is-complete .bs-stepper-circle {
-  background: linear-gradient(135deg, rgba(114, 173, 255, 0.96), rgba(27, 76, 181, 0.96));
-  color: #fff;
-  border-color: rgba(185, 221, 255, 0.26);
-}
-
-.wizard-stepper .step.is-current .bs-stepper-circle,
-.wizard-stepper .step.active .bs-stepper-circle {
-  color: #1c1203;
-  background: linear-gradient(135deg, var(--gold-soft), var(--gold));
-  border-color: rgba(255, 219, 147, 0.26);
-  box-shadow:
-    0 0 1.5rem rgba(242, 187, 77, 0.28),
-    0 0 0 0.18rem rgba(255, 216, 124, 0.12);
-  transform: scale(1.07);
-}
-
-.wizard-stepper .bs-stepper-label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.08rem;
-  line-height: 1.15;
-}
-
-.step-kicker {
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(161, 203, 255, 0.76);
-}
-
-.step-title {
-  font-size: 1rem;
-  font-weight: 700;
-  color: inherit;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.wizard-stepper .progress {
+.quiz-shell .progress {
   height: 1.25rem;
   overflow: hidden;
   border-radius: 999px;
@@ -640,7 +497,7 @@ body::after {
     0 0 0.9rem rgba(90, 147, 255, 0.08);
 }
 
-.wizard-stepper .progress-bar {
+.quiz-shell .progress-bar {
   font-weight: 800;
   letter-spacing: 0.12em;
   color: #120d03;
@@ -660,13 +517,13 @@ body::after {
   margin-right: auto;
 }
 
-.bs-stepper-content {
+.quiz-content {
   position: relative;
   max-width: 980px;
   margin: 0 auto;
 }
 
-.bs-stepper-content > .content {
+.quiz-content > .quiz-panel {
   position: relative;
   counter-reset: question;
   min-height: 21rem;
@@ -685,7 +542,7 @@ body::after {
     0 0 0 1px rgba(255, 214, 125, 0.04);
 }
 
-.bs-stepper-content > .content::before {
+.quiz-content > .quiz-panel::before {
   content: "";
   position: absolute;
   inset: 1rem;
@@ -697,11 +554,11 @@ body::after {
     radial-gradient(circle at bottom, rgba(91, 154, 255, 0.06), transparent 30%);
 }
 
-.quiz-flow .bs-stepper-content {
+.quiz-flow .quiz-content {
   max-width: 760px;
 }
 
-.quiz-flow .bs-stepper-content > .content {
+.quiz-flow .quiz-content > .quiz-panel {
   min-height: 0;
   counter-reset: none;
 }
@@ -928,7 +785,7 @@ body::after {
   display: none !important;
 }
 
-.finish-panel {
+.result-panel {
   text-align: center;
   background:
     radial-gradient(circle at 50% 0%, rgba(255, 212, 122, 0.16), transparent 28%),
@@ -1026,7 +883,7 @@ body::after {
     radial-gradient(circle at 50% 100%, rgba(105, 168, 255, 0.08), transparent 34%);
 }
 
-.finish-panel:not(.finish-revealed) .result-stage {
+.result-panel:not(.finish-revealed) .result-stage {
   opacity: 0.84;
   transform: translateY(6px) scale(0.994);
 }
@@ -1061,7 +918,7 @@ body::after {
   text-transform: uppercase;
 }
 
-#qoute {
+#quote {
   margin: 0 auto 1.2rem;
   max-width: 38rem;
   padding: 1.05rem 1.15rem;
@@ -1227,14 +1084,14 @@ body::after {
   border-radius: 0.95rem;
 }
 
-.wizard-stepper.is-auto-advancing .wizard-actions .btn-primary {
+.quiz-shell.is-auto-advancing .quiz-actions .btn-primary {
   box-shadow:
     0 1.2rem 2rem rgba(0, 0, 0, 0.22),
     0 0 0 0.16rem rgba(255, 214, 125, 0.12);
   filter: saturate(1.06);
 }
 
-.wizard-actions .btn {
+.quiz-actions .btn {
   min-height: 3.2rem;
   border-radius: 999px;
   font-weight: 800;
@@ -1259,18 +1116,18 @@ body::after {
   line-height: 1.5;
 }
 
-.wizard-actions .btn:hover:not(:disabled),
-.wizard-actions .btn:focus-visible {
+.quiz-actions .btn:hover:not(:disabled),
+.quiz-actions .btn:focus-visible {
   transform: translateY(-1px);
   box-shadow: 0 1.2rem 2.1rem rgba(0, 0, 0, 0.22);
   filter: saturate(1.04);
 }
 
-.wizard-actions .btn:disabled {
+.quiz-actions .btn:disabled {
   box-shadow: none;
 }
 
-.wizard-actions .btn-primary {
+.quiz-actions .btn-primary {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0)),
     linear-gradient(90deg, #ffe9b4 0%, #ffd881 20%, #f2bb4d 52%, #ffd881 82%, #ffe9b4 100%);
@@ -1278,7 +1135,7 @@ body::after {
   color: #1d1104;
 }
 
-.wizard-actions .btn-outline-secondary {
+.quiz-actions .btn-outline-secondary {
   color: #eef5ff;
   border-color: rgba(114, 173, 255, 0.26);
   background:
@@ -1336,7 +1193,7 @@ h6.text-muted {
   animation-name: resultSpotlight;
 }
 
-.finish-panel.result-spotlight .result-stage {
+.result-panel.result-spotlight .result-stage {
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.06),
     0 1.6rem 2.9rem rgba(0, 0, 0, 0.3),
@@ -1348,7 +1205,7 @@ h6.text-muted {
   animation: resultSweep 0.86s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.finish-panel.finish-revealed .result-stage {
+.result-panel.finish-revealed .result-stage {
   opacity: 1;
   transform: translateY(0) scale(1);
   box-shadow:
@@ -1357,35 +1214,34 @@ h6.text-muted {
     0 0 0 0.16rem rgba(255, 214, 125, 0.08);
 }
 
-.finish-panel.finish-revealed .result-label {
+.result-panel.finish-revealed .result-label {
   animation: revealCard 0.28s ease both;
 }
 
-.finish-panel.finish-revealed #points {
+.result-panel.finish-revealed #points {
   animation: revealAmount 0.48s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
-.finish-panel.finish-revealed .result-score {
+.result-panel.finish-revealed .result-score {
   animation: revealCard 0.34s ease 0.06s both;
 }
 
-.finish-panel.finish-revealed #qoute {
+.result-panel.finish-revealed #quote {
   animation: revealCard 0.38s ease 0.12s both;
 }
 
-.finish-panel.finish-revealed .result-herd {
+.result-panel.finish-revealed .result-herd {
   animation: revealCard 0.38s ease 0.16s both;
 }
 
-.finish-panel.finish-revealed #cowImages img {
+.result-panel.finish-revealed #cowImages img {
   animation: cowPop 0.4s ease both;
 }
 
 .option-group .btn:focus-within,
-.wizard-actions .btn:focus-visible,
+.quiz-actions .btn:focus-visible,
 #resultCalc:focus-visible,
-.share-links a:focus-visible,
-.wizard-stepper .step-trigger:focus-visible {
+.share-links a:focus-visible {
   outline: none;
   box-shadow: 0 0 0 0.24rem rgba(255, 208, 115, 0.18);
 }
@@ -1556,18 +1412,10 @@ h6.text-muted {
   .quiz-round-track {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-
-  .wizard-stepper .line {
-    display: none;
-  }
-
-  .wizard-stepper .step {
-    flex: 1 0 32%;
-  }
 }
 
 @media (max-width: 991.98px) {
-  #wizard {
+  #quizExperience {
     padding-top: 2rem;
   }
 
@@ -1579,27 +1427,23 @@ h6.text-muted {
     justify-self: start;
   }
 
-  .wizard-stepper .step {
-    flex: 1 0 calc(50% - 0.4rem);
-  }
-
-  .quiz-flow .bs-stepper-content {
+  .quiz-flow .quiz-content {
     max-width: 100%;
   }
 }
 
 @media (max-width: 767.98px) {
-  #wizard {
+  #quizExperience {
     padding-top: 1.25rem;
     padding-bottom: 3rem;
   }
 
-  .wizard-card {
+  .quiz-card {
     padding: 1rem;
     border-radius: 1.35rem;
   }
 
-  .wizard-card::after {
+  .quiz-card::after {
     left: 0.9rem;
     right: 0.9rem;
   }
@@ -1632,14 +1476,6 @@ h6.text-muted {
     font-size: 0.88rem;
   }
 
-  .wizard-stepper .step {
-    flex: 1 0 calc(50% - 0.35rem);
-  }
-
-  .wizard-stepper .step-trigger {
-    padding: 0.8rem 0.9rem;
-  }
-
   .question-row {
     padding-bottom: 1.2rem;
   }
@@ -1659,7 +1495,7 @@ h6.text-muted {
     font-size: 0.98rem;
   }
 
-  .wizard-actions .btn {
+  .quiz-actions .btn {
     width: 100%;
   }
 
@@ -1692,7 +1528,7 @@ h6.text-muted {
   }
 
   .share-links a:hover,
-  .wizard-actions .btn:hover:not(:disabled),
+  .quiz-actions .btn:hover:not(:disabled),
   #resultCalc:hover,
   .option-group .btn:hover {
     transform: none !important;


### PR DESCRIPTION
## Summary
- rename stepper-era wrappers and selectors to match the current quiz flow
- remove dormant stepper CSS and stale tab/ARIA leftovers
- replace inline answer/reveal handlers with centralized JavaScript listeners
- normalize per-question radio names while preserving the `label.active input` scoring contract
- fix legacy naming debt such as `qoute` to `quote` and align related docs

## Testing
- Verified in headless Chrome at desktop, tablet, mobile, and reduced-motion settings
- Confirmed one-question flow, auto-advance, back/continue behavior, progress sync, result reveal, cow rendering, and fairness feedback
- Confirmed no severe console errors in the verified flow